### PR TITLE
update readme to reflect discord username change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PZ-Libraries
 
-If you have trouble with the tutorial you can contact me on discord `Konijima#9279` or **open an issue**.  
+If you have trouble with the tutorial you can contact me on discord `konijima` or **open an issue**.  
 If you have **suggestion** you can **fork** and create a **pull request**.
 
 Hopefully I made this as easy as possible to understand.


### PR DESCRIPTION
Discord usernames have changed from the `name#ident` system to the current `username` system.

This change updates the contact information in the README associated with this tutorial.

I was debating changing the line to feature 

> - If you have trouble with the tutorial you can contact me on discord `konijima` (formerly `Konijima#9279`), or **open an issue**.  

But that seemed to detract from the **open an issue** section.

Also I was debating putting the word 'at' or the phrase 'at username' before the current (actual) discord username `konijima`.  That would read:
> - If you have trouble with the tutorial you can contact me on discord at my username `konijima` or **open an issue**.  

I can amend if any of these are preferred.